### PR TITLE
Fix(frontend): Remove unnecessary optional chaining in TestListComponent

### DIFF
--- a/frontend/src/app/components/test-list/test-list.component.html
+++ b/frontend/src/app/components/test-list/test-list.component.html
@@ -37,8 +37,8 @@
         <td>{{ s.title }}</td>
         <td>
           <div class="test-hierarchy">
-            <span class="stream">{{ s.stream?.name || 'N/A' }}</span>
-            <span class="paper" *ngIf="s.paper?.name">/ {{ s.paper?.name }}</span>
+            <span class="stream">{{ s.stream.name || 'N/A' }}</span>
+            <span class="paper" *ngIf="s.paper.name">/ {{ s.paper.name }}</span>
           </div>
         </td>
         <td>


### PR DESCRIPTION
The Angular compiler issued NG8107 warnings for unnecessary optional chaining (`?.`) in the TestListComponent template. This occurs when the type of the object on the left side of the `?.` does not include `null` or `undefined`.

The `TestSeries` interface defines `stream` and `paper` as non-optional objects, each with a non-optional `name` string property. Based on these type definitions, the `?.` operators were redundant.

This commit removes the `?.` from:
- `s.stream?.name` (now `s.stream.name`)
- `s.paper?.name` (now `s.paper.name`)

The existing template logic (`|| 'N/A'` and `*ngIf`) already handles cases where the `name` property itself might be missing or empty, so the runtime behavior remains consistent while resolving the compiler warnings.